### PR TITLE
Allow i3lock-fancy-rapid `pixel` argument

### DIFF
--- a/betterlockscreen_rapid
+++ b/betterlockscreen_rapid
@@ -15,7 +15,7 @@ else
 	echo "Invalid argument radius $1" >&2
 	exit 1
 fi
-if [ "$2" -gt "0" ]; then
+if [ "$2" = "pixel" ] || [ "$2" -gt "0" ]; then
 	time="$2"
 else
 	echo "Invalid argument time $2" >&2


### PR DESCRIPTION
https://github.com/yvbbrjdr/i3lock-fancy-rapid/commit/f0c51c0ef8b45195ab93e1f0471958ee9d11043f added support for pixelization instead of bluring.

This PR simply allows `pixel` as a valid argument in addition to the times the blur is applied.